### PR TITLE
Add Taft Test as an image placeholder provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ web development, test cases and many more.
 * [Generic tool](https://placeholder.com/)
 * [Morgan fillman](https://morganfillman.space/)
 * [Place bear](https://www.placebear.com)
+* [Taft Test](https://tafttest.com/)
 
 ### Libraries
 


### PR DESCRIPTION
[Taft Test](https://tafttest.com/) is a pretty cool placeholder service for images based on this blog post by the creator of Pinboard: http://idlewords.com/talks/website_obesity.htm

Please consider adding Taft to your list. 🙇 
